### PR TITLE
FOLIO-3563: Bump spring-context, jackson-databind-nullable, jackson-annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
     <core.yaml.file>${project.basedir}/src/main/resources/swagger.api/core.yaml</core.yaml.file>
 
-    <jackson-databind-nullable.version>0.2.1</jackson-databind-nullable.version>
+    <jackson-databind-nullable.version>0.2.3</jackson-databind-nullable.version>
     <swagger.annotations.version>1.6.3</swagger.annotations.version>
   </properties>
 
@@ -30,7 +30,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
-      <version>5.3.13</version>
+      <version>5.3.22</version>
       <scope>provided</scope>
     </dependency>
 
@@ -58,7 +58,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>2.13.0</version>
+      <version>2.13.3</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
Upgrade spring-context from 5.3.13 to 5.3.22 fixing Remote Code Execution
in sub-dependency spring-beans https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Upgrade jackson-databind-nullable from 0.2.1 to 0.2.3 fixing Deserialization of Untrusted Data in sub-dependency jackson-databind https://nvd.nist.gov/vuln/detail/CVE-2019-12384

Upgrade jackson-annotations from 2.13.0 to 2.13.3 to be in sync with jackson-databind.